### PR TITLE
Fix for unescaped brackets being fed to regex

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,10 @@
+## 0.3.1 – 2025-02-09
+
+### Fixed
+
+- Fixed bug where brackets (`[]`) were not properly escaped from glyphs string,
+  causing glyph filtering to work incorrectly (thanks @jmsole!)
+
 ## 0.3.0 – 2025-02-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wordsiv"
-version = "0.2.5"
+version = "0.3.1"
 description = "Generate text with a limited character set for font proofing"
 authors = ["Chris Pauley <cmpauley@gmail.com>"]
 license = "MIT"

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -277,6 +277,13 @@ def test_vocab_filter_glyphs_case_cap_force():
     assert vc.filter(glyphs="Ddos", case="cap_force") == (("Ddos", 6),)
 
 
+def test_vocab_filter_glyphs_contains_special_chars():
+    test_data = "grape\t1\napple\t2\nApple\t3\nBart\t4\nBART\t5\nDDoS\t6"
+    vc = Vocab(bicameral=True, lang="en", data=test_data)
+
+    assert vc.filter(glyphs="[]+apple[]{}.*$^", case="any_og") == (("apple", 2),)
+
+
 def test_vocab_filter_wl():
     test_data = "apple\t10\nbanana\t5\njoe\t2"
     vc = Vocab(bicameral=True, lang="en", data=test_data)

--- a/wordsiv/_filter.py
+++ b/wordsiv/_filter.py
@@ -160,6 +160,7 @@ def _filter_wl_substr(
 def _filter_case(wc_str, case, glyphs, bicameral):
     if not bicameral:
         if glyphs:
+            glyphs = regex.escape(glyphs)
             return _findall_recase(wc_str, f"[{glyphs}]+")
         else:
             return wc_str.splitlines()
@@ -172,6 +173,7 @@ def _filter_case(wc_str, case, glyphs, bicameral):
             # case "any_og" means any unmodified words from vocab
             if glyphs:
                 # return all vocab words we can display with glyphs as is
+                glyphs = regex.escape(glyphs)
                 return _findall_recase(wc_str, f"[{glyphs}]+")
             else:
                 # return all vocab words


### PR DESCRIPTION
This fixes #43. I've tested for my use cases, but I am not sure how it might affect other functionality.